### PR TITLE
Check if history functions are undefined

### DIFF
--- a/lib/location.js
+++ b/lib/location.js
@@ -22,8 +22,12 @@ var usingAppcache = function() {
   return !! Package.appcache;
 }
 
+var replaceStateUndefined = function() {
+  return history === undefined || history.pushState === undefined || history.replaceState === undefined || (typeof history.pushState !== "function");
+}
+
 var shouldUseHashPaths = function () {
-  return Location.options.useHashPaths || isIE8() || isIE9() || usingAppcache();
+  return Location.options.useHashPaths || isIE8() || isIE9() || usingAppcache() || replaceStateUndefined();
 };
 
 var isUsingHashPaths = function () {
@@ -46,7 +50,7 @@ var set = function (state) {
 
     // return true to indicate state was set to a new value.
     return true;
-  } 
+  }
 
   // state not set
   return false;
@@ -55,7 +59,7 @@ var set = function (state) {
 var setStateFromEventHandler = function () {
   var href = location.href;
   var state;
-  
+
   if (isUsingHashPaths()) {
     state = new State(urlFromHashStyle(href));
   } else {
@@ -80,14 +84,14 @@ var go = function (url, options) {
   var state = new State(url, options);
 
   runHandlers('go', state);
-  
+
   if (set(state)) {
     Deps.afterFlush(function () {
       // if after we've flushed if nobody has cancelled the state then change
       // the url.
       if (!state.isCancelled()) {
         if (isUsingHashPaths()) {
-          location.hash = fixHashPath(url); 
+          location.hash = fixHashPath(url);
         } else {
           if (options.replaceState === true)
             history.replaceState(options.historyState, null, url);


### PR DESCRIPTION
I ran into the issue in Awesomium that history.replaceState is undefined (obviously doesn't support it). There are a lot of other browsers than IE that don't support these history APIs. We should at least do a basic check to see if they are undefined before trying to call them. This fixes compatibility with older browsers.
