### PR TITLE
Fix relative links if HashPaths are used

### DIFF
--- a/lib/location.js
+++ b/lib/location.js
@@ -116,6 +116,15 @@ var onClickHandler = function (e) {
       href = el.href;
       path = el.pathname + el.search + el.hash;
     }
+	//HashPaths break relative links since the pathname is wrong
+	if (shouldUseHashPaths()) {
+		//If this is a relative link:
+		if (!el.attributes["href"].nodeValue.startsWith("/")) {
+			//Take the current location, remove everything after the last / and add the new location
+			var pathname = Iron.Location.get().pathname.replace(/[^\/]*$/, "") + el.attributes["href"].nodeValue
+			path = pathname + el.search + el.hash;
+		}
+	}
 
     // ie9 omits the leading slash in pathname - so patch up if it's missing
     path = path.replace(/(^\/?)/,"/");


### PR DESCRIPTION
If HashPaths are used relative links like: 
`<a href="relative">` 
will always point to `/relative` instead of `/current/path/relative`