### PR TITLE
refactor: use jQuery as a weak dependency (similar as Blaze)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@ Iron.Location
 ==============================================================================
 Reactive urls that work with IE8/9 and modern pushState browsers.
 
+## Installation
+This package has a weak dependency on jQuery (similar as Blaze),
+so you can add jQuery to your Meteor app from a [CDN](https://code.jquery.com/) or a [Meteor package](https://atmospherejs.com/meteor/jquery):
+```
+meteor add jquery
+```
+
 ## Example
 
 ```javascript

--- a/package.js
+++ b/package.js
@@ -5,7 +5,7 @@ Package.describe({
   git: 'https://github.com/eventedmind/iron-location.git'
 });
 
-Package.on_use(function (api) {
+Package.onUse(function (api) {
   api.versionsFrom('METEOR@0.9.2');
 
   api.use('underscore');
@@ -19,17 +19,17 @@ Package.on_use(function (api) {
 
   api.use('appcache', {weak: true});
 
-  api.add_files('lib/utils.js', 'client');
-  api.add_files('lib/state.js', 'client');
-  api.add_files('lib/location.js', 'client');
+  api.addFiles('lib/utils.js', 'client');
+  api.addFiles('lib/state.js', 'client');
+  api.addFiles('lib/location.js', 'client');
 
   api.export(['urlToHashStyle', 'urlFromHashStyle'], 'client', {testOnly: true});
 });
 
-Package.on_test(function (api) {
+Package.onTest(function (api) {
   api.use('iron:location');
   api.use('tinytest');
   api.use('test-helpers');
 
-  api.add_files('test/location_test.js', 'client');
+  api.addFiles('test/location_test.js', 'client');
 });

--- a/package.js
+++ b/package.js
@@ -10,7 +10,7 @@ Package.on_use(function (api) {
 
   api.use('underscore');
   api.use('tracker');
-  api.use('jquery');
+  api.use('jquery', { weak: true });
 
   api.use('iron:core@1.0.11');
   api.imply('iron:core');


### PR DESCRIPTION
Now we are able to add jQuery from CDN directly to <head>.
jQuery does not need to be part of the initial JS bundle (and users might have it cached already)